### PR TITLE
add step duration line to TMC5160 configs

### DIFF
--- a/config/generic-mellow-super-infinty-hv.cfg
+++ b/config/generic-mellow-super-infinty-hv.cfg
@@ -244,6 +244,7 @@ max_z_accel: 100
 ##diag1_pin: PG12
 #run_current: 0.800
 #stealthchop_threshold: 999999
+#step_pulse_duration: 0.000004 # this is a known issue with mellow boards. some have reported success with values as low as .000001. Note that this will limit your top speed 
 
 #[tmc5160 stepper_y]
 #cs_pin: PF12
@@ -251,6 +252,7 @@ max_z_accel: 100
 ##diag1_pin: PG11
 #run_current: 0.800
 #stealthchop_threshold: 999999
+#step_pulse_duration: 0.000004 # this is a known issue with mellow boards. some have reported success with values as low as .000001. Note that this will limit your top speed 
 
 #[tmc5160 stepper_z]
 #cs_pin: PF15
@@ -258,6 +260,7 @@ max_z_accel: 100
 ##diag1_pin: PG10
 #run_current: 0.650
 #stealthchop_threshold: 999999
+#step_pulse_duration: 0.000004 # this is a known issue with mellow boards. some have reported success with values as low as .000001. Note that this will limit your top speed 
 
 #[tmc5160 extruder]
 #cs_pin: PE7
@@ -265,6 +268,7 @@ max_z_accel: 100
 ##diag1_pin: PG9
 #run_current: 0.800
 #stealthchop_threshold: 999999
+#step_pulse_duration: 0.000004 # this is a known issue with mellow boards. some have reported success with values as low as .000001. Note that this will limit your top speed 
 
 #[tmc5160 extruder1]
 #cs_pin: PE10
@@ -272,6 +276,7 @@ max_z_accel: 100
 ##diag1_pin: PD7
 #run_current: 0.800
 #stealthchop_threshold: 999999
+#step_pulse_duration: 0.000004 # this is a known issue with mellow boards. some have reported success with values as low as .000001. Note that this will limit your top speed 
 
 #[tmc5160 extruder2]
 #cs_pin: PF1
@@ -279,6 +284,7 @@ max_z_accel: 100
 ##diag1_pin: PD6
 #run_current: 0.800
 #stealthchop_threshold: 999999
+#step_pulse_duration: 0.000004 # this is a known issue with mellow boards. some have reported success with values as low as .000001. Note that this will limit your top speed 
 
 #[tmc5160 extruder3]
 #cs_pin: PG2
@@ -286,6 +292,7 @@ max_z_accel: 100
 ##diag1_pin: PA8
 #run_current: 0.800
 #stealthchop_threshold: 999999
+#step_pulse_duration: 0.000004 # this is a known issue with mellow boards. some have reported success with values as low as .000001. Note that this will limit your top speed 
 
 #[tmc5160 extruder4]
 #cs_pin: PG5
@@ -293,6 +300,7 @@ max_z_accel: 100
 ##diag1_pin: PF3
 #run_current: 0.800
 #stealthchop_threshold: 999999
+#step_pulse_duration: 0.000004 # this is a known issue with mellow boards. some have reported success with values as low as .000001. Note that this will limit your top speed 
 
 
 ########################################


### PR DESCRIPTION
with step_duration line missing TMC5160s will misstep. See https://github.com/Klipper3d/klipper/issues/5232